### PR TITLE
Feature RA-760: use wide characters in pugixml

### DIFF
--- a/src/pugiconfig.hpp
+++ b/src/pugiconfig.hpp
@@ -15,7 +15,7 @@
 #define HEADER_PUGICONFIG_HPP
 
 // Uncomment this to enable wchar_t mode
-// #define PUGIXML_WCHAR_MODE
+#define PUGIXML_WCHAR_MODE
 
 // Uncomment this to enable compact mode
 // #define PUGIXML_COMPACT


### PR DESCRIPTION
All pugixml does is to read output from efsvss*.exe executables. This is formatted in UTF-16LE. I think pugi is capable of reading it anyway, but it converts it to the format used. I hope this improves performance since it reads and stores in wide characters now.
